### PR TITLE
Modify rendering of icon tokens to display tooltip

### DIFF
--- a/addons/mobdb/mobdb.lua
+++ b/addons/mobdb/mobdb.lua
@@ -1,6 +1,6 @@
 addon.name      = 'mobdb'
 addon.author    = 'Thorny';
-addon.version   = '1.05';
+addon.version   = '1.06';
 addon.desc      = 'Displays various information about monsters.';
 addon.link      = 'https://ashitaxi.com/';
 

--- a/addons/mobdb/tokens.lua
+++ b/addons/mobdb/tokens.lua
@@ -10,6 +10,9 @@ gTokenState = {
     DrawImage = function(this, fileName)
         this:ProcessSameLines();
         imgui.Image(tonumber(ffi.cast("uint32_t", gTextures.Cache[fileName])), {13 * gSettings.Scale, 13 * gSettings.Scale }, { 0, 0 }, { 1, 1 }, { 1, 1, 1, 1 }, { 0, 0, 0, 0 });
+        if imgui.IsItemHovered() then
+            imgui.SetTooltip(fileName);
+        end
     end,
     DrawText = function(this, text)
         this:ProcessSameLines();


### PR DESCRIPTION
I am pretty new to the game and didn't really know what the different icons mean when selecting a mob so I added this very small change to to show tooltips when hovering.

There are probably cases where it won't make the most sense because the text being used for the tooltip is just a lookup for an image file but it has already helped me a lot.